### PR TITLE
Change code snippets to comply with Namesake identifier similarity metrics

### DIFF
--- a/snippets/different/orthographic_1.py
+++ b/snippets/different/orthographic_1.py
@@ -1,14 +1,14 @@
-def function(t):
-    a = ""
-    for u in t:
+def function(input):
+    string = ""
+    for u in input:
         if u.isalpha():
             # get ascii value of b
             x = ord(u)
             x -= 32
             # convert ascii number to char
-            z = chr(x)
-            a += z
+            l = chr(x)
+            string += l
         else:
-            a += u
+            string += u
 
-    return a
+    return string

--- a/snippets/different/orthographic_2.py
+++ b/snippets/different/orthographic_2.py
@@ -1,12 +1,12 @@
-def function(a):
+def function(input):
     # sort the list in ascending order
-    a = sorted(a, reverse=False)
-    l = len(a)
-    u = []
+    input = sorted(input, reverse=False)
+    length = len(input)
+    lst = []
     t = []
-    for i in range(l):
-        if a[i] % 2 == 0:
-            u.append(a[i])
+    for index in range(length):
+        if input[index] % 2 == 0:
+            lst.append(input[index])
         else:
-            t.insert(0, a[i])
-    return u, t
+            t.insert(0, input[index])
+    return lst, t

--- a/snippets/different/orthographic_3.py
+++ b/snippets/different/orthographic_3.py
@@ -1,11 +1,11 @@
-def function(t):
+def function(input):
     x = ""
     u = ""
     # for each word in the string
-    for z in t.split():
-        if z[0] in ["a", "e", "i", "o", "u", "y"]:
-            x = x + z + " "
+    for j in input.split():
+        if j[0] in ["a", "e", "i", "o", "u", "y"]:
+            x = x + j + " "
         else:
-            u = u + z + " "
+            u = u + j + " "
 
     return x, u

--- a/snippets/different/orthographic_4.py
+++ b/snippets/different/orthographic_4.py
@@ -1,20 +1,20 @@
-def function(a, b):
-    l = len(a)
-    u = 0
-    m = 1e9
-    c = ""
-    x = ""
-    for i in range(l):
-        k = len(b[i])
+def function(a, input):
+    length = len(a)
+    num = 0
+    integer = 1e9
+    var = ""
+    ret = ""
+    for i in range(length):
+        y = len(input[i])
         r = 0
-        for j in range(k):
-            if b[i][j] == 1:
+        for index in range(y):
+            if input[i][index] == 1:
                 r += 1
-        if r > u:
-            c = a[i]
-            u = r
-        if r < m:
-            x = a[i]
-            m = r
+        if r > num:
+            var = a[i]
+            num = r
+        if r < integer:
+            ret = a[i]
+            integer = r
 
-    return c, x
+    return var, ret

--- a/snippets/different/phonological_1.py
+++ b/snippets/different/phonological_1.py
@@ -19,8 +19,8 @@ def function(input, ker, pad=False):
 
         sub = data[i - ker_pad: i + ker_pad + 1]
         value = 0
-        for j in range(len(ker)):
-            value += ker[j]*sub[j]
+        for index in range(len(ker)):
+            value += ker[index]*sub[index]
 
         output.append(value)
 

--- a/snippets/different/phonological_2.py
+++ b/snippets/different/phonological_2.py
@@ -7,12 +7,3 @@ def function(points, func):
         err += (xy_pair[1] - y_approx)**2
 
     return err/len(points)
-
-
-points = [(0, 0), (1, 1/2), (3, 4.5)]
-
-
-def f(x): return 0.5*x**2
-
-
-print(function(points, f))

--- a/snippets/different/phonological_4.py
+++ b/snippets/different/phonological_4.py
@@ -1,18 +1,18 @@
 def function(x, index=False):
 
-    max_x = max_i = min_i = 0
+    var = num = integer = 0
     min_x = 1e9
 
     for i in range(len(x)):
         if x[i] < min_x:
             min_x = x[i]
-            min_i = i
+            integer = i
 
-        elif x[i] > max_x:
-            max_x = x[i]
-            max_i = i
+        elif x[i] > var:
+            var = x[i]
+            num = i
 
     if index:
-        return (min_i, max_i)
+        return (integer, num)
     else:
-        return (min_x, max_x)
+        return (min_x, var)

--- a/snippets/different/semantic_1.py
+++ b/snippets/different/semantic_1.py
@@ -1,24 +1,24 @@
-def function(a, b):
-    i = 0
-    while i < len(a):
-        print(i)
-        if type(a[i]) == str:
-            b.append(a[i])
-            a.remove(a[i])
-        elif type(a[i]) == float:
-            b.append("0")
-            a.remove(a[i])
+def function(a, input):
+    index = 0
+    while index < len(a):
+        print(index)
+        if type(a[index]) == str:
+            input.append(a[index])
+            a.remove(a[index])
+        elif type(a[index]) == float:
+            input.append("0")
+            a.remove(a[index])
         else:
-            i += 1
-    j = 0
-    while j < len(b):
-        if type(b[j]) == int:
-            a.append(b[j])
-            b.remove(b[j])
-        elif type(b[j]) == float:
+            index += 1
+    index = 0
+    while index < len(input):
+        if type(input[index]) == int:
+            a.append(input[index])
+            input.remove(input[index])
+        elif type(input[index]) == float:
             a.append(0)
-            b.remove(b[j])
+            input.remove(input[index])
         else:
-            j += 1
+            index += 1
 
-    return a, b
+    return a, input

--- a/snippets/different/semantic_2.py
+++ b/snippets/different/semantic_2.py
@@ -1,17 +1,17 @@
 def function(a):
-    b = False
-    c = False
-    for x in a:
-        if len(x) < 5:
-            b = True
+    var = False
+    boolean = False
+    for element in a:
+        if len(element) < 5:
+            var = True
         else:
-            if len(x) < 10:
-                c = True
-        if b:
-            print(x[0])
-        elif c:
-            print(b)
+            if len(element) < 10:
+                boolean = True
+        if var:
+            print(element[0])
+        elif boolean:
+            print(var)
         else:
-            print(x[1])
-        b = False
-        c = False
+            print(element[1])
+        var = False
+        boolean = False

--- a/snippets/different/semantic_3.py
+++ b/snippets/different/semantic_3.py
@@ -1,12 +1,12 @@
-def function(a, b):
-    c = []
-    for x in a:
-        for y in x:
-            t = False
-            if y in b:
-                t = True
-            if x in b:
-                t = False
-            if t:
-                c.append(y)
-    return c
+def function(a, param):
+    lst = []
+    for element in a:
+        for y in element:
+            boolean = False
+            if y in param:
+                boolean = True
+            if element in param:
+                boolean = False
+            if boolean == True:
+                lst.append(y)
+    return lst

--- a/snippets/different/semantic_4.py
+++ b/snippets/different/semantic_4.py
@@ -1,29 +1,29 @@
-def function(a):
-    l = len(a)
-    i = 0
+def function(input):
+    l = len(input)
+    index = 0
     b = False
-    c = False
+    boolean = False
     x = True
     y = False
-    while i < l:
-        if a[i] != 0 and x is True:
-            c = True
-        elif a[i] == 0 and x is True:
-            print(a[i])
-        elif a[i] != 0 and b is True:
-            print(a[i])
-        elif a[i] == 0 and b is True:
+    while index < l:
+        if input[index] != 0 and x is True:
+            boolean = True
+        elif input[index] == 0 and x is True:
+            print(input[index])
+        elif input[index] != 0 and b is True:
+            print(input[index])
+        elif input[index] == 0 and b is True:
             y = True
 
         if y:
             x = True
             b = False
-            c = False
+            boolean = False
             y = False
-        if c:
+        if boolean:
             b = True
             x = False
-            c = False
+            boolean = False
             y = False
 
-        i += 1
+        index += 1

--- a/snippets/similar/orthographic_2.py
+++ b/snippets/similar/orthographic_2.py
@@ -1,12 +1,12 @@
-def function(lst1):
+def function(o):
     # sort the list in ascending order
-    lst1 = sorted(lst1, reverse=False)
-    l = len(lst1)
-    lst2 = []
-    lst3 = []
-    for i in range(l):
-        if lst1[i] % 2 == 0:
-            lst2.append(lst1[i])
+    o = sorted(o, reverse=False)
+    l = len(o)
+    i = []
+    j = []
+    for c in range(l):
+        if o[c] % 2 == 0:
+            i.append(o[c])
         else:
-            lst3.insert(0, lst1[i])
-    return lst2, lst3
+            j.insert(0, o[c])
+    return i, j

--- a/snippets/similar/orthographic_3.py
+++ b/snippets/similar/orthographic_3.py
@@ -1,10 +1,10 @@
-def function(string):
-    words1 = ""
-    words2 = ""
-    for word in string.split():
-        if word[0] in ["a", "e", "i", "o", "u", "y"]:
-            words1 = words1 + word + " "
+def function(m):
+    u = ""
+    n = ""
+    for v in m.split():
+        if v[0] in ["a", "e", "i", "o", "u", "y"]:
+            u = u + v + " "
         else:
-            words2 = words2 + word + " "
+            n = n + v + " "
 
-    return words1, words2
+    return u, n

--- a/snippets/similar/orthographic_4.py
+++ b/snippets/similar/orthographic_4.py
@@ -1,20 +1,20 @@
-def function(player_list, scorecard_list):
-    l = len(player_list)
-    most_holes = 0
-    least_holes = 1e9
-    most_holes_player = ""
-    least_holes_player = ""
+def function(z, s):
+    l = len(z)
+    q = 0
+    p = 1e9
+    b = ""
+    d = ""
     for i in range(l):
-        k = len(scorecard_list[i])
-        num_hole_in_ones = 0
-        for j in range(k):
-            if scorecard_list[i][j] == 1:
-                num_hole_in_ones += 1
-        if num_hole_in_ones > most_holes:
-            most_holes_player = player_list[i]
-            most_holes = num_hole_in_ones
-        if num_hole_in_ones < least_holes:
-            least_holes_player = player_list[i]
-            least_holes = num_hole_in_ones
+        f = len(s[i])
+        g = 0
+        for j in range(f):
+            if s[i][j] == 1:
+                g += 1
+        if g > q:
+            b = z[i]
+            q = g
+        if g < p:
+            d = z[i]
+            p = g
 
-    return most_holes_player, least_holes_player
+    return b, d

--- a/snippets/similar/phonological_1.py
+++ b/snippets/similar/phonological_1.py
@@ -19,8 +19,8 @@ def function(input, ker, pad=False):
 
         cur = data[i - ker_pad: i + ker_pad + 1]
         value = 0
-        for j in range(len(ker)):
-            value += ker[j]*cur[j]
+        for index in range(len(ker)):
+            value += ker[index]*cur[index]
 
         output.append(value)
 

--- a/snippets/similar/phonological_2.py
+++ b/snippets/similar/phonological_2.py
@@ -7,12 +7,3 @@ def function(points, square):
         err += (pair[1] - y_approx)**2
 
     return err/len(points)
-
-
-points = [(0, 0), (1, 1/2), (3, 4.5)]
-
-
-def f(x): return 0.5*x**2
-
-
-print(function(points, f))

--- a/snippets/similar/phonological_2.py
+++ b/snippets/similar/phonological_2.py
@@ -1,10 +1,10 @@
-def function(points, func):
+def function(points, square):
 
     err = 0
 
-    for xy_pair in points:
-        y_approx = func(xy_pair[0])
-        err += (xy_pair[1] - y_approx)**2
+    for pair in points:
+        y_approx = square(pair[0])
+        err += (pair[1] - y_approx)**2
 
     return err/len(points)
 

--- a/snippets/similar/semantic_1.py
+++ b/snippets/similar/semantic_1.py
@@ -1,24 +1,24 @@
-def function(input_list, input_array):
-    i = 0
-    while i < len(input_list):
-        print(i)
-        if type(input_list[i]) == str:
-            input_array.append(input_list[i])
-            input_list.remove(input_list[i])
-        elif type(input_list[i]) == float:
-            input_array.append("0")
-            input_list.remove(input_list[i])
+def function(list, array):
+    index = 0
+    while index < len(list):
+        print(index)
+        if type(list[index]) == str:
+            array.append(list[index])
+            list.remove(list[index])
+        elif type(list[index]) == float:
+            array.append("0")
+            list.remove(list[index])
         else:
-            i += 1
-    j = 0
-    while j < len(input_array):
-        if type(input_array[j]) == int:
-            input_list.append(input_array[j])
-            input_array.remove(input_array[j])
-        elif type(input_array[j]) == float:
-            input_list.append(0)
-            input_array.remove(input_array[j])
+            index += 1
+    index = 0
+    while index < len(array):
+        if type(array[index]) == int:
+            list.append(array[index])
+            array.remove(array[index])
+        elif type(array[index]) == float:
+            list.append(0)
+            array.remove(array[index])
         else:
-            j += 1
+            index += 1
 
-    return input_list, input_array
+    return list, array

--- a/snippets/similar/semantic_2.py
+++ b/snippets/similar/semantic_2.py
@@ -1,7 +1,7 @@
-def function(str_list):
+def function(a):
     short_string = False
     small_string = False
-    for little_string in str_list:
+    for little_string in a:
         if len(little_string) < 5:
             short_string = True
         else:

--- a/snippets/similar/semantic_3.py
+++ b/snippets/similar/semantic_3.py
@@ -1,12 +1,12 @@
-def function(input_list, string):
-    output_list = []
-    for char in input_list:
+def function(a, string):
+    lst = []
+    for char in a:
         for letter in char:
             add = False
             if letter in string:
                 add = True
             if char in string:
                 add = False
-            if add:
-                output_list.append(letter)
-    return output_list
+            if add == True:
+                lst.append(letter)
+    return lst

--- a/snippets/similar/semantic_4.py
+++ b/snippets/similar/semantic_4.py
@@ -1,18 +1,18 @@
-def function(input_list):
-    l = len(input_list)
-    i = 0
+def function(input):
+    l = len(input)
+    index = 0
     start = False
     begin = False
     stop = True
     end = False
-    while i < l:
-        if input_list[i] != 0 and stop == True:
+    while index < l:
+        if input[index] != 0 and stop == True:
             begin = True
-        elif input_list[i] == 0 and stop == True:
-            print(input_list[i])
-        elif input_list[i] != 0 and start == True:
-            print(input_list[i])
-        elif input_list[i] == 0 and start == True:
+        elif input[index] == 0 and stop == True:
+            print(input[index])
+        elif input[index] != 0 and start == True:
+            print(input[index])
+        elif input[index] == 0 and start == True:
             end = True
 
         if end:
@@ -26,4 +26,4 @@ def function(input_list):
             begin = False
             end = False
 
-        i += 1
+        index += 1


### PR DESCRIPTION
Changes in this PR:
- Each code snippet in the `snippets/different` folder should have no detected identifier similarity from Namesake.
- (in progress) Each code snippet in `snippets/similar` should only have its specified type of identifier similarity.
  - orthographic similarity snippets fully comply
  - phonological similarity snippets do not all comply
    - `similar/phonological_2.py`: Namesake detects no phonological similarity between `err, pair, square`. they rhyme though.
    - `similar/phonological_4.py`: Namesake detects extra semantic similarity between `max_y, max_i` and `min_y, min_i`
  - semantic similarity snippets do not all comply
    - `similar/semantic_1.py`: Namesake detects semantic similarity between `index, list` but not `array, list`.
    - `similar/semantic_3.py`: Namesake detects similarity between `a, letter` but not `char, letter` or `string, char`

Let me know what you guys think of these exceptions. I think we could theoretically make peace with them but it makes us less able to quantify the amount of similarity in each snippet which is not good.