### PR TITLE
Update orthographic and semantic similarity

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,262 @@
+make orthdiff
+python3 namesake.py ../IdentifierSimilarity/snippets/different/orthographic_1.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 17 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/orthographic_2.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 22 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/orthographic_3.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 14 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/orthographic_4.py
+
+
+orthographic similarity:
+	[a] on line 22 and [b] on line 23 are 0.60 similar!
+	[b] on line 23 and [r] on line 9 are 0.46 similar!
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 40 identifiers, there are 2 warnings.
+make phondiff
+python3 namesake.py ../IdentifierSimilarity/snippets/different/phonological_1.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 43 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/phonological_2.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 18 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/phonological_3.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 15 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/phonological_4.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 29 identifiers, there are 0 warnings.
+make semdiff
+python3 namesake.py ../IdentifierSimilarity/snippets/different/semantic_1.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 52 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/semantic_2.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 21 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/semantic_3.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 18 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/different/semantic_4.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 42 identifiers, there are 0 warnings.
+make phonsim
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/phonological_1.py
+
+
+orthographic similarity:
+
+phonological similarity:
+	[cur] on line 20 and [ker] on line 3 are 1.00 similar!
+
+semantic similarity:
+
+Processing 43 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/phonological_2.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 18 identifiers, there are 0 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/phonological_3.py
+
+
+orthographic similarity:
+
+phonological similarity:
+	[row] on line 9 and [rho] on line 11 are 1.00 similar!
+
+semantic similarity:
+
+Processing 15 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/phonological_4.py
+
+
+orthographic similarity:
+
+phonological similarity:
+	[max_y] on line 3 and [max_i] on line 3 are 0.83 similar!
+	[min_i] on line 3 and [min_y] on line 4 are 0.83 similar!
+
+semantic similarity:
+	[max_y] on line 3 and [max_i] on line 3 are 0.94 similar!
+	[min_i] on line 3 and [min_y] on line 4 are 0.94 similar!
+
+Processing 29 identifiers, there are 4 warnings.
+make orthsim
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/orthographic_1.py
+
+
+orthographic similarity:
+	[b] on line 3 and [d] on line 9 are 0.64 similar!
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 16 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/orthographic_2.py
+
+
+orthographic similarity:
+	[q] on line 5 and [d] on line 6 are 0.70 similar!
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 21 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/orthographic_3.py
+
+
+orthographic similarity:
+	[n] on line 2 and [u] on line 3 are 0.67 similar!
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 13 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/orthographic_4.py
+
+
+orthographic similarity:
+	[g] on line 3 and [q] on line 4 are 0.63 similar!
+
+phonological similarity:
+
+semantic similarity:
+
+Processing 38 identifiers, there are 1 warnings.
+make semsim
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/semantic_1.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+	[index] on line 2 and [list] on line 24 are 0.93 similar!
+
+Processing 50 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/semantic_2.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+	[short_string] on line 2 and [little_string] on line 4 are 1.00 similar!
+
+Processing 20 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/semantic_3.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+	[character] on line 3 and [letter] on line 4 are 0.93 similar!
+
+Processing 16 identifiers, there are 1 warnings.
+python3 namesake.py ../IdentifierSimilarity/snippets/similar/semantic_4.py
+
+
+orthographic similarity:
+
+phonological similarity:
+
+semantic similarity:
+	[start] on line 4 and [begin] on line 5 are 1.00 similar!
+
+Processing 41 identifiers, there are 1 warnings.

--- a/snippets/different/orthographic_1.py
+++ b/snippets/different/orthographic_1.py
@@ -12,3 +12,5 @@ def function(input):
             string += u
 
     return string
+
+input = "in 2 years, i will get three new pets!"

--- a/snippets/different/orthographic_2.py
+++ b/snippets/different/orthographic_2.py
@@ -10,3 +10,5 @@ def function(input):
         else:
             t.insert(0, input[index])
     return lst, t
+
+input = [6, 8, 35, 17, 0, 9, 45]

--- a/snippets/different/orthographic_3.py
+++ b/snippets/different/orthographic_3.py
@@ -9,3 +9,5 @@ def function(input):
             u = u + j + " "
 
     return x, u
+
+input = "the inclination angle of some galaxy will affect the component of the"

--- a/snippets/different/orthographic_4.py
+++ b/snippets/different/orthographic_4.py
@@ -18,3 +18,10 @@ def function(a, input):
             integer = r
 
     return var, ret
+
+a = ["Jerry", "George", "Newman"]
+b = [
+    [1, 2, 4, 3, 1, 1, 3],
+    [4, 2, 1, 1, 1, 3, 1],
+    [6, 2, 1, 3, 4, 3, 2]
+]

--- a/snippets/different/semantic_1.py
+++ b/snippets/different/semantic_1.py
@@ -22,3 +22,6 @@ def function(a, input):
             index += 1
 
     return a, input
+
+a = [2, "three", "four", 5, 6.7, "seven", "eight", 9, "ten"]
+input = ["zero", 1, "two", 4.5, 8, 16, "thirty-two", 64.0]

--- a/snippets/different/semantic_2.py
+++ b/snippets/different/semantic_2.py
@@ -15,3 +15,5 @@ def function(a):
             print(element[1])
         var = False
         boolean = False
+
+a = ["treble", "bass", "microphone", "amplifier", "guitar", "glasses", "anyone"]

--- a/snippets/different/semantic_3.py
+++ b/snippets/different/semantic_3.py
@@ -10,3 +10,6 @@ def function(a, param):
             if boolean == True:
                 lst.append(y)
     return lst
+
+a = ["string", "forget", "about", "i got strings", "who is that"]
+param = "strings are what i got strings are what i need"

--- a/snippets/different/semantic_4.py
+++ b/snippets/different/semantic_4.py
@@ -27,3 +27,5 @@ def function(input):
             y = False
 
         index += 1
+
+input = [0, 4, 5, 1, 0, 1, 0, 0, 9]

--- a/snippets/similar/orthographic_1.py
+++ b/snippets/similar/orthographic_1.py
@@ -1,14 +1,14 @@
-def function(p):
-    q = ""
-    for b in p:
+def function(input):
+    string = ""
+    for b in input:
         if b.isalpha():
             # get ascii value of b
-            g = ord(b)
-            g -= 32
+            x = ord(b)
+            x -= 32
             # convert ascii number to char
-            d = chr(g)
-            q += d
+            d = chr(x)
+            string += d
         else:
-            q += b
+            string += b
 
-    return q
+    return string

--- a/snippets/similar/orthographic_2.py
+++ b/snippets/similar/orthographic_2.py
@@ -1,12 +1,13 @@
-def function(o):
+def function(input):
     # sort the list in ascending order
-    o = sorted(o, reverse=False)
-    l = len(o)
-    i = []
-    j = []
-    for c in range(l):
-        if o[c] % 2 == 0:
-            i.append(o[c])
+    input = sorted(input, reverse=False)
+    length = len(input)
+    q = []
+    d = []
+    for index in range(length):
+        if input[index] % 2 == 0:
+            q.append(input[index])
         else:
-            j.insert(0, o[c])
-    return i, j
+            d.insert(0, input[index])
+    return q, d
+

--- a/snippets/similar/orthographic_3.py
+++ b/snippets/similar/orthographic_3.py
@@ -1,10 +1,11 @@
-def function(m):
-    u = ""
+def function(input):
     n = ""
-    for v in m.split():
-        if v[0] in ["a", "e", "i", "o", "u", "y"]:
-            u = u + v + " "
+    u = ""
+    # for each word in the string
+    for elem in input.split():
+        if elem[0] in ["a", "e", "i", "o", "u", "y"]:
+            n = n + elem + " "
         else:
-            n = n + v + " "
+            u = u + elem + " "
 
-    return u, n
+    return n, u

--- a/snippets/similar/orthographic_4.py
+++ b/snippets/similar/orthographic_4.py
@@ -1,20 +1,20 @@
-def function(z, s):
-    l = len(z)
-    q = 0
-    p = 1e9
-    b = ""
-    d = ""
-    for i in range(l):
-        f = len(s[i])
-        g = 0
-        for j in range(f):
-            if s[i][j] == 1:
-                g += 1
-        if g > q:
-            b = z[i]
-            q = g
-        if g < p:
-            d = z[i]
-            p = g
+def function(param, input):
+    length = len(param)
+    g = 0
+    q = 1e9
+    var = ""
+    ret = ""
+    for elem in range(length):
+        value = len(input[elem])
+        num = 0
+        for index in range(value):
+            if input[elem][index] == 1:
+                num += 1
+        if num > g:
+            var = param[elem]
+            g = num
+        if num < q:
+            ret = param[elem]
+            q = num
 
-    return b, d
+    return var, ret

--- a/snippets/similar/semantic_2.py
+++ b/snippets/similar/semantic_2.py
@@ -1,17 +1,17 @@
 def function(a):
     short_string = False
-    small_string = False
+    boolean = False
     for little_string in a:
         if len(little_string) < 5:
             short_string = True
         else:
             if len(little_string) < 10:
-                small_string = True
+                boolean = True
         if short_string:
             print(little_string[0])
-        elif small_string:
+        elif boolean:
             print(short_string)
         else:
             print(little_string[1])
         short_string = False
-        small_string = False
+        boolean = False

--- a/snippets/similar/semantic_3.py
+++ b/snippets/similar/semantic_3.py
@@ -1,11 +1,11 @@
-def function(a, string):
+def function(param, string):
     lst = []
-    for char in a:
-        for letter in char:
+    for character in param:
+        for letter in character:
             add = False
             if letter in string:
                 add = True
-            if char in string:
+            if character in string:
                 add = False
             if add == True:
                 lst.append(letter)

--- a/snippets/similar/semantic_4.py
+++ b/snippets/similar/semantic_4.py
@@ -3,27 +3,27 @@ def function(input):
     index = 0
     start = False
     begin = False
-    stop = True
-    end = False
+    x = True
+    y = False
     while index < l:
-        if input[index] != 0 and stop == True:
+        if input[index] != 0 and x is True:
             begin = True
-        elif input[index] == 0 and stop == True:
+        elif input[index] == 0 and x is True:
             print(input[index])
-        elif input[index] != 0 and start == True:
+        elif input[index] != 0 and start is True:
             print(input[index])
-        elif input[index] == 0 and start == True:
-            end = True
+        elif input[index] == 0 and start is True:
+            y = True
 
-        if end:
-            stop = True
+        if y:
+            x = True
             start = False
             begin = False
-            end = False
+            y = False
         if begin:
             start = True
-            stop = False
+            x = False
             begin = False
-            end = False
+            y = False
 
         index += 1

--- a/snippets/test_snippets.py
+++ b/snippets/test_snippets.py
@@ -33,44 +33,48 @@ from different.phonological_4 import function as phono_4_dif
 
 
 def test_ortho_1():
-    test_str = 'this is a test'
+    test_str = "in 2 years, i will get three new pets!"
 
     dif_output = ortho_1_dif(test_str)
     sim_output = ortho_1_sim(test_str)
 
     assert dif_output == sim_output
-    assert dif_output == 'THIS IS A TEST'
+    assert dif_output == 'IN 2 YEARS, I WILL GET THREE NEW PETS!'
 
 
 def test_ortho_2():
-    test_list = [0, 1, 2, 3, 4, 5]
+    test_list = [6, 8, 35, 17, 0, 9, 45]
 
     dif_output = ortho_2_dif(test_list)
     sim_output = ortho_2_sim(test_list)
 
     assert dif_output == sim_output
-    assert dif_output == ([0, 2, 4], [5, 3, 1])
+    assert dif_output == ([0, 6, 8], [45, 35, 17, 9])
 
 
 def test_ortho_3():
-    test_str = 'remove all the words starting with vowels!'
+    test_str = "the inclination angle of some galaxy will affect the component of the"
 
     dif_output = ortho_3_dif(test_str)
     sim_output = ortho_3_sim(test_str)
 
     assert dif_output == sim_output
-    assert dif_output == ('all ', 'remove the words starting with vowels! ')
+    assert dif_output == ('inclination angle of affect of ', 'the some galaxy will the component the ')
 
 
 def test_ortho_4():
-    test_players = ['Alex', 'Bella']
-    test_scores = [[2, 2], [1, 1]]
+    test_players = ["Jerry", "George", "Newman"]
+    test_scores = [
+                [1, 2, 4, 3, 1, 1, 3],
+                [4, 2, 1, 1, 1, 3, 1],
+                [6, 2, 1, 3, 4, 3, 2]
+            ]
 
     dif_output = ortho_4_dif(test_players, test_scores)
     sim_output = ortho_4_sim(test_players, test_scores)
 
     assert dif_output == sim_output
-    assert dif_output == ('Bella', 'Alex')
+    assert dif_output == ('George', 'Newman')
 
 
 def test_phono_1():
@@ -157,6 +161,16 @@ def test_semantic_1():
 
 def test_semantic_2():
     # function doesn't return anything
+    # printed output:
+
+    # False
+    # b
+    # i
+    # False
+    # False
+    # False
+    # False
+
     pass
 
 
@@ -175,4 +189,11 @@ def test_semantic_3():
 
 def test_semantic_4():
     # function doesn't return anything
+
+    # printed output:
+    # 0
+    # 5
+    # 1
+    # 0
+
     pass


### PR DESCRIPTION
This PR updates orthographic and semantic similarity.

Orthographic similarity can't reach a similarity score of `1.00`. In this code, it hovers between `0.63` and `0.70`, with the most similar identifiers being `q, d`.

Two of the semantic snippets contain identifiers with `1.00` scores. The other two have scores of `0.93`, but changing those to attempt to reach `1.00` would compromise identifier names that make sense within the context of the function. **Do you guys think we should sacrifice the contextually sound identifiers to make the score `1.00` or leave it at `0.93`?**